### PR TITLE
change kansas city wizards key from 'kcwizards' to 'kansascity'

### DIFF
--- a/2005/mls.yml
+++ b/2005/mls.yml
@@ -8,7 +8,7 @@ teams:
 - chivasusa
 - nymetro
 - columbus
-- kcwizards
+- kansascity
 - dallas
 - sanjose
 - dcunited

--- a/2006/mls.yml
+++ b/2006/mls.yml
@@ -6,7 +6,7 @@ fixtures:
 - mls
 teams:
 - dallas
-- kcwizards
+- kansascity
 - galaxy
 - dcunited
 - chivasusa

--- a/2007/mls.yml
+++ b/2007/mls.yml
@@ -16,5 +16,5 @@ teams:
 - newengland
 - newyork
 - dallas
-- kcwizards
+- kansascity
 - toronto

--- a/2008/mls.yml
+++ b/2008/mls.yml
@@ -8,7 +8,7 @@ teams:
 - columbus
 - saltlake
 - newengland
-- kcwizards
+- kansascity
 - colorado
 - dallas
 - chicago

--- a/2009/mls.yml
+++ b/2009/mls.yml
@@ -7,7 +7,7 @@ fixtures:
 teams:
 - seattle
 - houston
-- kcwizards
+- kansascity
 - dallas
 - sanjose
 - chivasusa

--- a/2010/mls.yml
+++ b/2010/mls.yml
@@ -10,7 +10,7 @@ teams:
 - columbus
 - dallas
 - newyork
-- kcwizards
+- kansascity
 - sanjose
 - galaxy
 - houston


### PR DESCRIPTION
Kansas City Wizards rebranded and became Sporting KC in 2011 and so I think that the key should be changed to 'kansascity'. Sporting KC and Kansas City Wizards are also both listed under the 'kansascity' key - right now the database fails to build since there's no team with the 'kcwizards' key and I think this would be the best solution.