### PR TITLE
change New York Metros key from 'nymetro' to 'newyork'

### DIFF
--- a/2005/mls.yml
+++ b/2005/mls.yml
@@ -6,7 +6,7 @@ fixtures:
 - mls
 teams:
 - chivasusa
-- nymetro
+- newyork
 - columbus
 - kansascity
 - dallas

--- a/2005/mls.yml
+++ b/2005/mls.yml
@@ -8,7 +8,7 @@ teams:
 - chivasusa
 - nymetro
 - columbus
-- kcwizards
+- kansascity
 - dallas
 - sanjose
 - dcunited

--- a/2006/mls.yml
+++ b/2006/mls.yml
@@ -6,7 +6,7 @@ fixtures:
 - mls
 teams:
 - dallas
-- kcwizards
+- kansascity
 - galaxy
 - dcunited
 - chivasusa

--- a/2006/mls.yml
+++ b/2006/mls.yml
@@ -11,7 +11,7 @@ teams:
 - dcunited
 - chivasusa
 - houston
-- nymetro
+- newyork
 - colorado
 - columbus
 - saltlake

--- a/2007/mls.yml
+++ b/2007/mls.yml
@@ -16,5 +16,5 @@ teams:
 - newengland
 - newyork
 - dallas
-- kcwizards
+- kansascity
 - toronto

--- a/2008/mls.yml
+++ b/2008/mls.yml
@@ -8,7 +8,7 @@ teams:
 - columbus
 - saltlake
 - newengland
-- kcwizards
+- kansascity
 - colorado
 - dallas
 - chicago

--- a/2009/mls.yml
+++ b/2009/mls.yml
@@ -7,7 +7,7 @@ fixtures:
 teams:
 - seattle
 - houston
-- kcwizards
+- kansascity
 - dallas
 - sanjose
 - chivasusa

--- a/2010/mls.yml
+++ b/2010/mls.yml
@@ -10,7 +10,7 @@ teams:
 - columbus
 - dallas
 - newyork
-- kcwizards
+- kansascity
 - sanjose
 - galaxy
 - houston


### PR DESCRIPTION
sorry to make another pull request so soon after my previous one, but I tried building the mls database and it looks like the there's another key discrepancy with the New York Metrostars who became the New York Red Bulls in 2006.  I changed their key to 'newyork'. I checked and think that this is the last team in the dataset that has changed names.